### PR TITLE
Fix unused variable in analyze_file

### DIFF
--- a/app1.py
+++ b/app1.py
@@ -3216,15 +3216,6 @@ def analyze_file(file_stream) -> dict | None:
     """
     df = pd.read_excel(file_stream)
 
-    dias_semana = [
-        "Lunes",
-        "Martes",
-        "Miércoles",
-        "Jueves",
-        "Viernes",
-        "Sábado",
-        "Domingo",
-    ]
 
     required_resources: list[list[int]] = [[] for _ in range(7)]
     for _, row in df.iterrows():


### PR DESCRIPTION
## Summary
- remove the `dias_semana` list from `analyze_file`
- run flake8 to confirm the unused variable warning is gone

## Testing
- `flake8 | grep 'F841' | grep 3219`

------
https://chatgpt.com/codex/tasks/task_e_6882b8cf9e688327884a3b0c09a37623