### PR TITLE
Fix newline spacing for about route

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -34,7 +34,7 @@ def home():
             result = app1.analyze_file(file.stream)
     return render_template_string(UPLOAD_FORM, result=result)
 
+
 @app.route('/about')
 def about():
     return 'About'
-


### PR DESCRIPTION
## Summary
- add an extra blank line before the `/about` route
- clean up trailing newline at EOF

## Testing
- `flake8 api/index.py`

------
https://chatgpt.com/codex/tasks/task_e_6882b8d0c6888327bf2612c02e27286c